### PR TITLE
Correct typo on landing page

### DIFF
--- a/ruby-monday-blog/app/views/static_pages/index.html.erb
+++ b/ruby-monday-blog/app/views/static_pages/index.html.erb
@@ -1,1 +1,1 @@
-<h1>Welcome to the Ruby-Monday blog!"</h1>
+<h1>Welcome to the Ruby-Monday blog!</h1>


### PR DESCRIPTION
I removed the quotation mark that I accidentally added in my initial request.
