### PR TITLE
post validation and shoulda matchers

### DIFF
--- a/ruby-monday-blog/Gemfile
+++ b/ruby-monday-blog/Gemfile
@@ -38,7 +38,10 @@ group :development, :test do
   
   # Install Capybara for testing
   gem 'capybara', '~> 2.4.4'
-
+  
+  # Install Shoulda Matchers for validation testing
+  gem 'shoulda'
+  
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 

--- a/ruby-monday-blog/Gemfile.lock
+++ b/ruby-monday-blog/Gemfile.lock
@@ -139,6 +139,12 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.1)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     spring (1.3.6)
     sprockets (3.2.0)
       rack (~> 1.0)
@@ -178,6 +184,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda
   spring
   turbolinks
   uglifier (>= 1.3.0)

--- a/ruby-monday-blog/app/models/post.rb
+++ b/ruby-monday-blog/app/models/post.rb
@@ -1,2 +1,4 @@
 class Post < ActiveRecord::Base
+  validates :body, presence: true
+  validates :title, presence: true
 end

--- a/ruby-monday-blog/spec/models/post_spec.rb
+++ b/ruby-monday-blog/spec/models/post_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe Post do
+  describe Post, 'validation' do
+    it {should validate_presence_of(:title)}
+    it {should validate_presence_of(:body)}
+  end
+
   describe "initial setup" do
     let(:post) {Post.create(title:"My Post", body:"My Content")}
 


### PR DESCRIPTION
In order to validate presence in the post model spec, I added the shoulda matchers gem.

testing past, currently the post model will not allow empty title or body.
