### PR TITLE
Added Vagrant to project for suckers like me and Tyler on Windows

### DIFF
--- a/Vagrant-setup/vagrant-postgres.sh
+++ b/Vagrant-setup/vagrant-postgres.sh
@@ -1,0 +1,102 @@
+#!/bin/sh -e
+
+# Edit the following to change the name of the database user that will be created:
+APP_DB_USER=vagrant
+APP_DB_PASS=vagrant
+
+# Edit the following to change the name of the database that is created (defaults to the user name)
+APP_DB_NAME=$APP_DB_USER
+
+# Edit the following to change the version of PostgreSQL that is installed
+PG_VERSION=9.4
+
+###########################################################
+# Changes below this line are probably not necessary
+###########################################################
+print_db_usage () {
+  echo "Your PostgreSQL database has been setup and can be accessed on your local machine on the forwarded port (default: 5432)"
+  echo "  Host: localhost"
+  echo "  Port: 5432"
+  echo "  Database: $APP_DB_NAME"
+  echo "  Username: $APP_DB_USER"
+  echo "  Password: $APP_DB_PASS"
+  echo ""
+  echo "Admin access to postgres user via VM:"
+  echo "  vagrant ssh"
+  echo "  sudo su - postgres"
+  echo ""
+  echo "psql access to app database user via VM:"
+  echo "  vagrant ssh"
+  echo "  sudo su - postgres"
+  echo "  PGUSER=$APP_DB_USER PGPASSWORD=$APP_DB_PASS psql -h localhost $APP_DB_NAME"
+  echo ""
+  echo "Env variable for application development:"
+  echo "  DATABASE_URL=postgresql://$APP_DB_USER:$APP_DB_PASS@localhost:5432/$APP_DB_NAME"
+  echo ""
+  echo "Local command to access the database via psql:"
+  echo "  PGUSER=$APP_DB_USER PGPASSWORD=$APP_DB_PASS psql -h localhost -p 5432 $APP_DB_NAME"
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+PROVISIONED_ON=/etc/vm_provision_on_timestamp
+if [ -f "$PROVISIONED_ON" ]
+then
+  echo "VM was already provisioned at: $(cat $PROVISIONED_ON)"
+  echo "To run system updates manually login via 'vagrant ssh' and run 'apt-get update && apt-get upgrade'"
+  echo ""
+  print_db_usage
+  exit
+fi
+
+PG_REPO_APT_SOURCE=/etc/apt/sources.list.d/pgdg.list
+if [ ! -f "$PG_REPO_APT_SOURCE" ]
+then
+  # Add PG apt repo:
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > "$PG_REPO_APT_SOURCE"
+
+  # Add PGDG repo key:
+  wget --quiet -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
+fi
+
+# Update package list and upgrade all packages
+apt-get update
+apt-get -y upgrade
+
+apt-get -y install "postgresql-$PG_VERSION" "postgresql-contrib-$PG_VERSION" "libpq-dev"
+
+PG_CONF="/etc/postgresql/$PG_VERSION/main/postgresql.conf"
+PG_HBA="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
+PG_DIR="/var/lib/postgresql/$PG_VERSION/main"
+
+# Edit postgresql.conf to change listen address to '*':
+sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" "$PG_CONF"
+
+# Append to pg_hba.conf to add password auth:
+echo "host    all             all             all                     md5" >> "$PG_HBA"
+
+# Explicitly set default client_encoding
+echo "client_encoding = utf8" >> "$PG_CONF"
+
+# Restart so that all new config is loaded:
+service postgresql restart
+
+cat << EOF | su - postgres -c psql
+-- Create the database user:
+CREATE USER $APP_DB_USER WITH PASSWORD '$APP_DB_PASS' SUPERUSER CREATEDB;
+
+
+-- Create the database:
+CREATE DATABASE $APP_DB_NAME WITH OWNER=$APP_DB_USER
+                                  LC_COLLATE='en_US.utf8'
+                                  LC_CTYPE='en_US.utf8'
+                                  ENCODING='UTF8'
+                                  TEMPLATE=template0;
+EOF
+
+# Tag the provision time:
+date > "$PROVISIONED_ON"
+
+echo "Successfully created PostgreSQL dev virtual machine."
+echo ""
+print_db_usage

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "fitmentgroup/rvmruby222"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.network "forwarded_port", guest: 5432, host: 5432
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+    vb.memory = "1024"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+
+  config.vm.provision :shell, :path => "Vagrant-setup/vagrant-postgres.sh"
+  config.vm.provision :shell, privileged: false, inline: <<-SHELL
+    sudo date > /etc/vagrant_provisioned_at
+    sudo apt-get -y install nodejs
+    gem install rails --no-ri --no-rdoc
+  SHELL
+end
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(2) do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 80, host: 80
   config.vm.network "forwarded_port", guest: 3000, host: 3000
   config.vm.network "forwarded_port", guest: 5432, host: 5432
   # Create a private network, which allows host-only access to the machine


### PR DESCRIPTION
I'd like to package this vagrant setup with the project, since a few of us (at least Tyler and myself) have to work off Windows a fair amount of time, and we're just talking about a few lines of text/code if someone prefers to ignore it. Alternatively, feel free to reject this. There was talk in #slack about how this might be too far off-topic.

The image referenced in the Vagrantfile is based on `ubuntu/trusty64` but includes RVM, ruby 2.2.2, git and bundler set up and ready to go. I started maintaining this image for exploring Ruby, and also giving me a good baseline to start for some work projects that we are testing in .rb https://atlas.hashicorp.com/fitmentgroup/boxes/rvmruby222

On top of this starting image:
- Postgres is installed with user vagrant:vagrant
- Rails is installed (not currently locked to a particular version, that's easy to fix though)
- ports are forwarded:
  - 80 > 80
  - 3000 > 3000
  - 5432 > 5432

After loading Vagrant, you just need to cd to /vagrant/ruby-monday-blog/ and run the usual bundle install, rake db tasks.
