### PR TITLE
Refactor javascript

### DIFF
--- a/ruby-monday-blog/app/assets/javascripts/application.js
+++ b/ruby-monday-blog/app/assets/javascripts/application.js
@@ -18,13 +18,12 @@
 
 $(function() {
   var flashCallback;
+  
   flashCallback = function() {
     return $(".alert").fadeOut();
   };
-  $(".flash-message").bind('click', (function(_this) {
-    return function(ev) {
-      return $(".alert").fadeOut();
-    };
-  })(this));
+  
+  $(".flash-message").on('click', flashCallback);
+  
   return setTimeout(flashCallback, 2000);
 });


### PR DESCRIPTION
`.on` is functionally the same as `.bind`

The jquery documentation recommends using `.on` starting with jQuery 1.7

http://api.jquery.com/bind/
