### PR TITLE
Enforce uniqueness validation on duplicate post tags

### DIFF
--- a/ruby-monday-blog/Gemfile.lock
+++ b/ruby-monday-blog/Gemfile.lock
@@ -43,7 +43,6 @@ GEM
       execjs
       json
     bcrypt (3.1.10)
-    bcrypt (3.1.10-x64-mingw32)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     bootstrap-sass (3.3.5.1)
@@ -107,8 +106,6 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    nokogiri (1.6.6.2-x64-mingw32)
-      mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
     paperclip (4.3.0)
       activemodel (>= 3.2.0)
@@ -117,7 +114,6 @@ GEM
       mime-types
       mimemagic (= 0.3.0)
     pg (0.18.2)
-    pg (0.18.2-x64-mingw32)
     populator (1.0.0)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -212,7 +208,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   animate-rails
@@ -237,6 +232,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.5

--- a/ruby-monday-blog/app/models/post_tag.rb
+++ b/ruby-monday-blog/app/models/post_tag.rb
@@ -1,4 +1,6 @@
 class PostTag < ActiveRecord::Base
   belongs_to :post
   belongs_to :tag
+
+  validates :tag, uniqueness: { scope: :post }
 end

--- a/ruby-monday-blog/db/migrate/20150811195313_add_uniqueness_constraint_to_post_tags.rb
+++ b/ruby-monday-blog/db/migrate/20150811195313_add_uniqueness_constraint_to_post_tags.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToPostTags < ActiveRecord::Migration
+  def change
+    add_index :post_tags, [:post_id, :tag_id], unique: true
+  end
+end

--- a/ruby-monday-blog/db/schema.rb
+++ b/ruby-monday-blog/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150724005116) do
+ActiveRecord::Schema.define(version: 20150811195313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 20150724005116) do
     t.integer "post_id", null: false
     t.integer "tag_id",  null: false
   end
+
+  add_index "post_tags", ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true, using: :btree
 
   create_table "posts", force: :cascade do |t|
     t.string   "title"

--- a/ruby-monday-blog/spec/models/post_tag_spec.rb
+++ b/ruby-monday-blog/spec/models/post_tag_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 describe PostTag do
-    it {should belong_to(:tag)}
-    it {should belong_to(:post)}
+  it { should belong_to(:tag) }
+  it { should belong_to(:post) }
+
+  let!(:post) { Post.create(body: 'A post body', title: 'A post title') }
+  let!(:tag)  { Tag.create(content: 'Tag content') }
+
+  it 'should allow tagging of posts' do
+    post.tags << tag
+    expect(post.tags).to match_array [tag]
+  end
+
+  it 'should prevent duplicate tags on posts (application layer)' do
+    post.tags << tag
+    expect { post.tags << tag }.to raise_error ActiveRecord::RecordInvalid
+  end
+
+  it 'should prevent duplicate tags on posts (database layer)' do
+    post.tags << tag
+    post_tag = PostTag.new(post: post, tag: tag)
+    expect { post_tag.save(validate: false) }.to raise_error ActiveRecord::RecordNotUnique
+  end
 end


### PR DESCRIPTION
Fixes #57.

Added test coverage as well.

It enforces uniqueness constraint on both application and database layer.
