### PR TITLE
Add version requirement for bundler in Gemfile

### DIFF
--- a/ruby-monday-blog/Gemfile
+++ b/ruby-monday-blog/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ### core dependencies
 gem 'rails', '4.2.0'
 gem 'pg'
+gem 'bundler', '1.10.6'
 # gem 'unicorn'
 
 ### front-end dependencies

--- a/ruby-monday-blog/Gemfile.lock
+++ b/ruby-monday-blog/Gemfile.lock
@@ -240,6 +240,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass
+  bundler (= 1.10.6)
   capybara (~> 2.4.4)
   devise
   factory_girl_rails (~> 4.4)
@@ -265,4 +266,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.3
+   1.10.6


### PR DESCRIPTION
Fixes #83 

I've made a test here.
I have installed version 1.10.5 of bundler and uninstalled the 1.10.6.

When I try to bundle it issues a warning

``` bash
Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
```

I think this helps to fix #83 
(at least people get a warning)
